### PR TITLE
improve portability, fix memory leak

### DIFF
--- a/MeshSmoother/BoundaryLayer/SmootherBoundaryLayer.C
+++ b/MeshSmoother/BoundaryLayer/SmootherBoundaryLayer.C
@@ -1,6 +1,7 @@
 /*---------------------------------------------------------------------------*\
   extBlockMesh
   Copyright (C) 2014 Etudes-NG
+  Copyright (C) 2020 OpenCFD Ltd.
   ---------------------------------
 License
     This file is part of extBlockMesh.
@@ -22,31 +23,38 @@ License
 
 #include "SmootherBoundaryLayer.H"
 
-// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
-
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
-
-Foam::SmootherBoundaryLayer::SmootherBoundaryLayer(const dictionary &blDict)
-:
-    _nbLayers(readLabel(blDict.lookup("nSurfaceLayers"))),
-    _expansionRatio(readScalar(blDict.lookup("expansionRatio"))),
-    _relativeSize(readBool(blDict.lookup("relativeSizes"))),
-    _finalLayerThickness(readScalar(blDict.lookup("finalLayerThickness")))
-{
-    Info<< "        - Number of BL       : " << _nbLayers << nl;
-    Info<< "        - Expansion ratio    : " << _expansionRatio << nl;
-    Info<< "        - Relatice size      : " << _relativeSize << nl;
-    Info<< "        - Final thickness    : " << _finalLayerThickness << nl;
-}
-
 
 Foam::SmootherBoundaryLayer::SmootherBoundaryLayer()
 :
-    _nbLayers(0.0),
-    _expansionRatio(1.0),
-    _relativeSize(true),
-    _finalLayerThickness(1)
+    _nbLayers(0),
+    _expansionRatio(1),
+    _finalLayerThickness(1),
+    _relativeSize(true)
 {}
+
+
+Foam::SmootherBoundaryLayer::SmootherBoundaryLayer(const dictionary& dict)
+:
+    SmootherBoundaryLayer()
+{
+    #if (OPENFOAM >= 1812)
+    dict.readEntry("nSurfaceLayers", _nbLayers);
+    dict.readEntry("expansionRatio", _expansionRatio);
+    dict.readEntry("finalLayerThickness", _finalLayerThickness);
+    dict.readEntry("relativeSizes", _relativeSize);
+    #else
+    dict.lookup("nSurfaceLayers") >> _nbLayers;
+    dict.lookup("expansionRatio") >> _expansionRatio;
+    dict.lookup("finalLayerThickness") >> _finalLayerThickness;
+    dict.lookup("relativeSizes") >> _relativeSize;
+    #endif
+
+    Info<< "        - Number of BL       : " << _nbLayers << nl
+        << "        - Expansion ratio    : " << _expansionRatio << nl
+        << "        - Relative size      : " << _relativeSize << nl
+        << "        - Final thickness    : " << _finalLayerThickness << nl;
+}
 
 
 // ************************************************************************* //

--- a/MeshSmoother/BoundaryLayer/SmootherBoundaryLayer.H
+++ b/MeshSmoother/BoundaryLayer/SmootherBoundaryLayer.H
@@ -36,26 +36,34 @@ namespace Foam
 
 class SmootherBoundaryLayer
 {
-    //- Private data
+    // Private Data
 
-        // Number of boundary layers
+        //- Number of boundary layers
         label _nbLayers;
 
-        // Expansion ratio
+        //- Expansion ratio
         scalar _expansionRatio;
 
-        // Relative size
-        bool _relativeSize;
-
-        // Wanted thickness of final added cell layer. If multiple
-        // layers is the thickness of the layer furthest away from the
-        // wall. Relative to undistorted size of cell outside layer.
+        //- Wanted thickness of final added cell layer.
+        // If multiple layers is the thickness of the layer furthest
+        // away from the wall.
+        // Relative to undistorted size of cell outside layer.
         scalar _finalLayerThickness;
 
+        //- Use relative size
+        bool _relativeSize;
+
 public:
-    SmootherBoundaryLayer(const dictionary &blDict);
-    SmootherBoundaryLayer();
+
+    // Constructors
+
+        //- Default construct
+        SmootherBoundaryLayer();
+
+        //- Construct from dictionary
+        explicit SmootherBoundaryLayer(const dictionary &blDict);
 };
+
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/MeshSmoother/Make/files
+++ b/MeshSmoother/Make/files
@@ -1,3 +1,5 @@
+$(BACKPORT_SOURCES)
+
 MeshSmoother.C
 SmootherBoundary.C
 SmootherControl.C

--- a/MeshSmoother/Make/options
+++ b/MeshSmoother/Make/options
@@ -1,25 +1,27 @@
 sinclude $(GENERAL_RULES)/module-path-user
 
 /* Failsafe - user location */
-ifeq (,$(strip $(FOAM_MODULE_APPBIN)))
-    FOAM_MODULE_APPBIN = $(FOAM_USER_APPBIN)
+ifeq (,$(strip $(FOAM_MODULE_LIBBIN)))
+    FOAM_MODULE_LIBBIN = $(FOAM_USER_LIBBIN)
 endif
 
 EXE_INC = \
     -I$(LIB_SRC)/fileFormats/lnInclude \
     -I$(LIB_SRC)/surfMesh/lnInclude \
-    -I$(LIB_SRC)/meshTools/lnInclude \
-    -I$(LIB_SRC)/mesh/blockMesh/lnInclude
+    -I$(LIB_SRC)/meshTools/lnInclude
 
 LIB_LIBS = \
     -lfileFormats \
     -lsurfMesh \
-    -lmeshTools \
-    -lblockMesh
+    -lmeshTools
 
-/* OpenFOAM-v1806: separate triSurface, no polyFields */
+BACKPORT_SOURCES :=
+
+/* Prior to OpenFOAM-v1806: separate triSurface, no polyFields */
 #if (OPENFOAM < 1806)
-EXE_INC += -I$(LIB_SRC)/finiteVolume/lnInclude -I$(LIB_SRC)/triSurface/lnInclude
 
-EXE_LIBS += -lfiniteVolume -ledgeMesh
+EXE_INC += -I$(LIB_SRC)/triSurface/lnInclude
+
+BACKPORT_SOURCES += backports/polyField/backport_polyFields.C
+
 #endif

--- a/MeshSmoother/MeshSmoother.C
+++ b/MeshSmoother/MeshSmoother.C
@@ -412,7 +412,7 @@ Foam::MeshSmoother::MeshSmoother
     const dictionary& smootherDict
 )
 :
-    _polyMesh(mesh),
+    _polyMesh(mesh)
 {
     const scalar time = _polyMesh->time().elapsedCpuTime();
 
@@ -428,7 +428,7 @@ Foam::MeshSmoother::MeshSmoother
 
     forAll(_cell, celli)
     {
-        _cell[cellI] = new SmootherCell(_polyMesh->cellShapes()[cellI]);
+        _cell[celli] = new SmootherCell(_polyMesh->cellShapes()[celli]);
     }
 
     // Analyse initial quality

--- a/MeshSmoother/MeshSmoother.H
+++ b/MeshSmoother/MeshSmoother.H
@@ -25,6 +25,7 @@ License
 #define MESHSMOOTHER_H
 
 #include "polyMesh.H"
+#include "scalarField.H"
 #include "PtrList.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
@@ -34,7 +35,6 @@ namespace Foam
 
 // Forward Declarations
 class blockMesh;
-class SmootherCell;
 class SmootherControl;
 class SmootherParameter;
 class SmootherBoundary;
@@ -50,13 +50,13 @@ class MeshSmoother
         // Pointer of parents
         polyMesh *_polyMesh;
 
+        // Current cell quality. See SmootherCell
+        scalarField _cellQuality;
+
         // MeshSmoother child items
         SmootherControl* _ctrl;
         SmootherParameter* _param;
         SmootherBoundary* _bnd;
-
-        // Smoother cell and points
-        List<SmootherCell*> _cell;
 
 
     // Private Member Functions

--- a/MeshSmoother/MeshSmoother.H
+++ b/MeshSmoother/MeshSmoother.H
@@ -1,6 +1,7 @@
 /*---------------------------------------------------------------------------*\
   extBlockMesh
   Copyright (C) 2014 Etudes-NG
+  Copyright (C) 2020 OpenCFD Ltd.
   ---------------------------------
 License
     This file is part of extBlockMesh.
@@ -24,14 +25,7 @@ License
 #define MESHSMOOTHER_H
 
 #include "polyMesh.H"
-
-#if (OPENFOAM >= 1806)
-    #include "polyFields.H"
-#else
-    #include "volFields.H"
-#endif
-
-#include <map>
+#include "PtrList.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -46,25 +40,15 @@ class SmootherParameter;
 class SmootherBoundary;
 
 /*---------------------------------------------------------------------------*\
-                      Class blockMeshSmoother Declaration
+                        Class MeshSmoother Declaration
 \*---------------------------------------------------------------------------*/
 
 class MeshSmoother
 {
-    // Typedefs
-
-        #if (OPENFOAM >= 1806)
-        typedef polyScalarField qualityFieldType;
-        #else
-        typedef volScalarField qualityFieldType;
-        #endif
-
-
     // Private Data
 
         // Pointer of parents
         polyMesh *_polyMesh;
-        blockMesh *_blocks;
 
         // MeshSmoother child items
         SmootherControl* _ctrl;
@@ -79,7 +63,7 @@ class MeshSmoother
 
         // Quality analysis
         void analyseMeshQuality();
-        void analyseMeshQuality(const labelHashSet &cell);
+        void analyseMeshQuality(const labelHashSet& cell);
         void qualityStats();
 
         // GETMe smoothing
@@ -97,10 +81,6 @@ class MeshSmoother
         bool runIteration();
         pointField getMovedPoints() const;
 
-
-        //- Write the mesh and meshQuality
-        void writeMesh(qualityFieldType& meshQuality) const;
-
         // Smoothing algo
         void GETMeSmoothing();
         void snapSmoothing();
@@ -109,13 +89,8 @@ public:
 
     //- Constructors
 
-        //- Construct from polyMesh and dictionary
-        MeshSmoother
-        (
-            polyMesh *mesh,
-            dictionary *smootherDict,
-            blockMesh *blocks = nullptr
-        );
+        //- Construct from polyMesh and smoother dictionary
+        MeshSmoother(polyMesh *mesh, const dictionary& smootherDict);
 
 
     //- Destructor
@@ -124,25 +99,13 @@ public:
 
     // Member Functions
 
-        //- Attach blocks to the smoother. A nullptr is allowed
-        void setBlocks(blockMesh* blocks);
-
         //- Smooth the mesh acording to smoothDict
         void update();
 
-        //- Smooth the mesh acording to smoothDict and write intermediate mesh
-        //  \return the number of fields written
-        label updateAndWrite(Time& runTime);
-
-        //- Smooth the mesh acording to smoothDict and write intermediate mesh
-        //  \return the number of fields written
-        label updateAndWrite
-        (
-            word& regionName,
-            word& defaultFacesName,
-            word& defaultFacesType,
-            Time& runTime
-        );
+        //- Smooth mesh acording to smoothDict,
+        //- writing intermediate mesh, optionally write the quality field
+        //  \return the number of time-steps written
+        label updateAndWrite(Time& runTime, const bool withQuality=false);
 
         //- Get tranformation treshold
         scalar getTransformationTreshold() const;

--- a/MeshSmoother/Point/Features/SmootherEdge.H
+++ b/MeshSmoother/Point/Features/SmootherEdge.H
@@ -38,13 +38,14 @@ class SmootherEdge
 :
     public SmootherFeature
 {
-
 public:
+
     SmootherEdge(const label ref, const label featureRef, const point &pt);
 
     void GETMeSmooth();
     void snap();
     void featLaplaceSmooth();
+
     bool isEdge() const {return true;}
     bool isSurface() const {return true;}
 };

--- a/MeshSmoother/Point/Features/SmootherFeature.H
+++ b/MeshSmoother/Point/Features/SmootherFeature.H
@@ -41,7 +41,7 @@ class SmootherFeature
 {
 protected:
 
-    // Protected data
+    // Protected Data
 
         //- Feature ref
         label _featureRef;
@@ -50,6 +50,7 @@ protected:
         point _snapPoint;
 
 public:
+
     SmootherFeature(const label ref, const label featureRef, const point &pt);
 
     ~SmootherFeature() {}

--- a/MeshSmoother/Point/Features/SmootherSurface.C
+++ b/MeshSmoother/Point/Features/SmootherSurface.C
@@ -21,12 +21,8 @@ License
 \*---------------------------------------------------------------------------*/
 
 #include "SmootherSurface.H"
-
-#include "polyMesh.H"
-
 #include "SmootherBoundary.H"
-
-// * * * * * * * * * * * * * * * Private Functions * * * * * * * * * * * * * //
+#include "polyMesh.H"
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 

--- a/MeshSmoother/Point/Features/SmootherSurface.H
+++ b/MeshSmoother/Point/Features/SmootherSurface.H
@@ -39,11 +39,13 @@ class SmootherSurface
     public SmootherFeature
 {
 public:
+
     SmootherSurface(const label ref, const label featureRef, const point &pt);
 
     void GETMeSmooth();
     void snap();
     void featLaplaceSmooth();
+
     bool isSurface() const {return true;}
 };
 

--- a/MeshSmoother/Point/SmootherPoint.C
+++ b/MeshSmoother/Point/SmootherPoint.C
@@ -61,6 +61,7 @@ void Foam::SmootherPoint::setStaticItems
     _polyMesh = mesh;
 }
 
+
 void Foam::SmootherPoint::laplaceSmooth()
 {
     const labelList& pp = _polyMesh->pointPoints(_ptRef);

--- a/MeshSmoother/Point/SmootherPoint.H
+++ b/MeshSmoother/Point/SmootherPoint.H
@@ -38,12 +38,14 @@ class SmootherPoint
 {
 protected:
 
-    // Protected data
+    // Static Data
 
         // Pointers
         static polyMesh* _polyMesh;
         static SmootherBoundary* _bnd;
         static SmootherParameter* _param;
+
+    // Protected data
 
         // Point storage
         point _initialPt; // Point before iteration
@@ -61,24 +63,27 @@ protected:
         label _ptRef;
 
 public:
+
     //- Constructors
+
+        //- Default construct
+        SmootherPoint();
 
         //- Construct from point ref
         SmootherPoint(const label ref, const point& pt);
 
-        // Empty constructor
-        SmootherPoint();
 
     //- Destructor
-    virtual ~SmootherPoint() {}
+    virtual ~SmootherPoint() = default;
 
-    //- Member functions
+
+    // Member Functions
 
         // Set boundary and control ref
-        void setStaticItems
+        static void setStaticItems
         (
-            SmootherBoundary *bnd,
-            SmootherParameter *param,
+            SmootherBoundary* bnd,
+            SmootherParameter* param,
             polyMesh* mesh
         );
 

--- a/MeshSmoother/SmootherBoundary.C
+++ b/MeshSmoother/SmootherBoundary.C
@@ -36,12 +36,19 @@ License
 
 // * * * * * * * * * * * * * * * Private Functions * * * * * * * * * * * * * //
 
-void Foam::SmootherBoundary::analyseDict(dictionary &snapDict)
+void Foam::SmootherBoundary::analyseDict(const dictionary& snapDict)
 {
-    _featureAngle = readScalar(snapDict.lookup("featureAngle"));
-    _minEdgeForFeature = readLabel(snapDict.lookup("minEdgeForFeature"));
-    _minFeatureEdgeLength = readScalar(snapDict.lookup("minFeatureEdgeLength"));
-    _writeFeatures = readBool(snapDict.lookup("writeFeatures"));
+    #if (OPENFOAM >= 1812)
+    snapDict.readEntry("featureAngle", _featureAngle);
+    snapDict.readEntry("minEdgeForFeature", _minEdgeForFeature);
+    snapDict.readEntry("minFeatureEdgeLength", _minFeatureEdgeLength);
+    snapDict.readEntry("writeFeatures", _writeFeatures);
+    #else
+    snapDict.lookup("featureAngle") >> _featureAngle;
+    snapDict.lookup("minEdgeForFeature") >> _minEdgeForFeature;
+    snapDict.lookup("minFeatureEdgeLength") >> _minFeatureEdgeLength;
+    snapDict.lookup("writeFeatures") >> _writeFeatures;
+    #endif
 
     Info<< "  snapControls:"  << nl
         << "    - Feature angle              : " << _featureAngle  << nl
@@ -126,7 +133,7 @@ void Foam::SmootherBoundary::analyseDict(dictionary &snapDict)
 
                 if (!exist)
                 {
-                    WarningIn("Foam::MeshSmoother::analyseDict()")
+                    WarningInFunction
                         << "Patch " << bndDefined[patchI]
                         << " definied in smootherDict is not existing in "
                         << "polyMesh, existing patch in polyMesh ares: "
@@ -508,12 +515,12 @@ void Foam::SmootherBoundary::createPoints(labelList &pointType)
 
 Foam::SmootherBoundary::SmootherBoundary
 (
-    dictionary &snapDict,
+    const dictionary& snapDict,
     polyMesh* mesh
 )
 :
     _polyMesh(mesh),
-    _point(List<SmootherPoint*>(_polyMesh->nPoints()))
+    _point(_polyMesh->nPoints())
 {
     analyseDict(snapDict);
     List<labelHashSet> pp(mesh->nPoints());
@@ -527,7 +534,8 @@ Foam::SmootherBoundary::SmootherBoundary
     }
 }
 
-// * * * * * * * * * * * * * * * * Desctructor  * * * * * * * * * * * * * * //
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * //
 
 Foam::SmootherBoundary::~SmootherBoundary()
 {

--- a/MeshSmoother/SmootherBoundary.H
+++ b/MeshSmoother/SmootherBoundary.H
@@ -71,6 +71,9 @@ class SmootherBoundary
         // Pointer to polyMesh
         polyMesh* _polyMesh;
 
+        // Point as SmootherPoints
+        List<SmootherPoint*> _point;
+
         // Searchable surfaces list
         List<triSurface*> _triSurfList;
         List<triSurfaceSearch*> _triSurfSearchList;
@@ -88,9 +91,6 @@ class SmootherBoundary
         std::map<label, label> _pointFeature;
         std::map<label, labelHashSet> _pointFeatureSet;
 
-        // Point as SmootherPoints
-        List<SmootherPoint*> _point;
-
         // Hash set of specific points
         labelHashSet _unsnapedPoint;
         labelHashSet _featuresPoint;
@@ -102,9 +102,10 @@ class SmootherBoundary
         label _minEdgeForFeature;
         bool _writeFeatures;
 
-    //- Private member functions
 
-        void analyseDict(dictionary &snapDict);
+    // Private Member Functions
+
+        void analyseDict(const dictionary& snapDict);
 
         labelList analyseFeatures
         (
@@ -139,12 +140,14 @@ public:
 
     //- Constructors
 
-        SmootherBoundary(dictionary& snapDict, polyMesh* mesh);
+        SmootherBoundary(const dictionary& snapDict, polyMesh* mesh);
+
 
     //- Destructor
     ~SmootherBoundary();
 
-    //- Member functions
+
+    // Member Functions
 
         // Get snaped point
         inline point snapToSurf(const label r, const point &pt) const;
@@ -169,6 +172,7 @@ public:
 
         void writeAllSurfaces(const label iterRef) const;
 };
+
 
 point SmootherBoundary::snapToSurf(const label r, const point &pt) const
 {

--- a/MeshSmoother/SmootherBoundary.H
+++ b/MeshSmoother/SmootherBoundary.H
@@ -1,6 +1,7 @@
 /*---------------------------------------------------------------------------*\
   extBlockMesh
   Copyright (C) 2014 Etudes-NG
+  Copyright (C) 2020 OpenCFD Ltd.
   ---------------------------------
 License
     This file is part of extBlockMesh.
@@ -39,6 +40,7 @@ License
 
 #include <map>
 #include <set>
+#include <memory>
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -110,7 +112,7 @@ class SmootherBoundary
         labelList analyseFeatures
         (
             List<labelHashSet>& pp,
-            std::set<std::set<label> >& fP
+            std::set<std::set<label>>& fP
         );
 
         void addTriFace(const label patch, triSurface *triSurf);
@@ -126,12 +128,12 @@ class SmootherBoundary
 
         void markPts
         (
-            surfaceFeatures *surfFeat,
+            const surfaceFeatures& surfFeat,
             std::map<label, label> &s2p,
             const bool uE,
             labelList &pointType,
             List<labelHashSet>& pp,
-            std::set<std::set<label> >& fP
+            std::set<std::set<label>>& fP
         );
 
         void createPoints(labelList &pointType);
@@ -165,7 +167,7 @@ public:
         (
             labelList& pointType,
             List<labelHashSet>& pp,
-            std::set<std::set<label> >& fP
+            std::set<std::set<label>>& fP
         ) const;
 
         void removeSnapPoint(const label ref);

--- a/MeshSmoother/SmootherCell.C
+++ b/MeshSmoother/SmootherCell.C
@@ -28,6 +28,15 @@ Foam::scalar Foam::SmootherCell::_transParam = 1.0;
 Foam::SmootherBoundary* Foam::SmootherCell::_bnd = nullptr;
 
 
+// * * * * * * * * * * * * * Static Member Functions * * * * * * * * * * * * //
+
+void Foam::SmootherCell::setStaticItems(SmootherBoundary* bnd, const scalar t)
+{
+    _transParam = t;
+    _bnd = bnd;
+}
+
+
 // * * * * * * * * * * * * * * * Private Functions * * * * * * * * * * * * * //
 
 Foam::scalar Foam::SmootherCell::tetCellQuality(const label ref) const
@@ -56,9 +65,10 @@ Foam::scalar Foam::SmootherCell::tetCellQuality(const label ref) const
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
-Foam::SmootherCell::SmootherCell(const cellShape &cell)
+Foam::SmootherCell::SmootherCell(const cellShape& shape)
 :
-    _cellShape(cell)
+    _cellShape(shape),
+    _quality(0)
 {}
 
 
@@ -66,7 +76,8 @@ Foam::SmootherCell::SmootherCell(const cellShape &cell)
 
 void Foam::SmootherCell::computeQuality()
 {
-    _quality = 0.0;
+    _quality = 0;
+
     forAll(_cellShape, ptI)
     {
         const scalar tetQuality(tetCellQuality(ptI));
@@ -128,13 +139,6 @@ Foam::pointField Foam::SmootherCell::geometricTransform()
     const pointField C(8, c);
 
     return pointField(C + length*(H - C));
-}
-
-
-void Foam::SmootherCell::setStaticItems(SmootherBoundary* bnd, const scalar &t)
-{
-    _transParam = t;
-    _bnd = bnd;
 }
 
 

--- a/MeshSmoother/SmootherCell.C
+++ b/MeshSmoother/SmootherCell.C
@@ -1,6 +1,7 @@
 /*---------------------------------------------------------------------------*\
   extBlockMesh
   Copyright (C) 2014 Etudes-NG
+  Copyright (C) 2020 OpenCFD Ltd.
   ---------------------------------
 License
     This file is part of extBlockMesh.
@@ -39,7 +40,11 @@ void Foam::SmootherCell::setStaticItems(SmootherBoundary* bnd, const scalar t)
 
 // * * * * * * * * * * * * * * * Private Functions * * * * * * * * * * * * * //
 
-Foam::scalar Foam::SmootherCell::tetCellQuality(const label ref) const
+Foam::scalar Foam::SmootherCell::tetCellQuality
+(
+    const cellShape& shape,
+    const label ref
+)
 {
     const label v1[] = {3, 0, 1, 2, 7, 4, 5, 6};
     const label v2[] = {4, 5, 6, 7, 5, 6, 7, 4};
@@ -47,9 +52,9 @@ Foam::scalar Foam::SmootherCell::tetCellQuality(const label ref) const
 
     const Tensor<scalar> mA
     (
-        relaxPt(v1[ref]) - relaxPt(ref),
-        relaxPt(v2[ref]) - relaxPt(ref),
-        relaxPt(v3[ref]) - relaxPt(ref)
+        relaxPt(shape[v1[ref]]) - relaxPt(shape[ref]),
+        relaxPt(shape[v2[ref]]) - relaxPt(shape[ref]),
+        relaxPt(shape[v3[ref]]) - relaxPt(shape[ref])
     );
     const scalar sigma(det(mA));
 
@@ -74,27 +79,27 @@ Foam::SmootherCell::SmootherCell(const cellShape& shape)
 
 // * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
 
-void Foam::SmootherCell::computeQuality()
+Foam::scalar Foam::SmootherCell::quality(const cellShape& shape)
 {
-    _quality = 0;
+    scalar avgQuality = 0;
 
-    forAll(_cellShape, ptI)
+    forAll(shape, pointi)
     {
-        const scalar tetQuality(tetCellQuality(ptI));
+        const scalar tetQuality(tetCellQuality(shape, pointi));
 
         if (tetQuality < ROOTVSMALL)
         {
-            _quality = 0;
-            return;
+            return 0;
         }
-        _quality += tetQuality;
+
+        avgQuality += tetQuality;
     }
 
-    _quality /= 8.0;
+    return (avgQuality / scalar(8));
 }
 
 
-Foam::pointField Foam::SmootherCell::geometricTransform()
+Foam::pointField Foam::SmootherCell::geometricTransform(const cellShape& shape)
 {
     // TODO if found a way to have the face label from cellShape,
     // store face centre in MeshSmoother and avoid use of pointFields dO
@@ -107,16 +112,24 @@ Foam::pointField Foam::SmootherCell::geometricTransform()
     const label g[] = {1, 4, 5, 6, 3, 7};
     const label h[] = {2, 5, 6, 7, 7, 6};
     const label i[] = {3, 1, 2, 3, 4, 5};
+
     for (label j = 0; j < 6; ++j)
     {
-        fc[j] = (initPt(f[j]) + initPt(g[j]) + initPt(h[j]) + initPt(i[j]))/4.0;
+        fc[j] =
+        (
+            initPt(shape[f[j]])
+          + initPt(shape[g[j]])
+          + initPt(shape[h[j]])
+          + initPt(shape[i[j]])
+        ) / 4.0;
     }
 
-    // Transfomred points
+    // Transformed points
     pointField H(8);
     const label a[] = {0, 0, 0, 0, 5, 5, 5, 5};
     const label b[] = {1, 2, 3, 4, 4, 1, 2, 3};
     const label d[] = {4, 1, 2, 3, 1, 2, 3, 4};
+
     for (label j = 0; j < 8; ++j)
     {
         const point c = (fc[a[j]] + fc[b[j]] + fc[d[j]])/3.0;
@@ -128,9 +141,14 @@ Foam::pointField Foam::SmootherCell::geometricTransform()
     scalar length = 0.0, lengthN = 0.0;
     const label k[] = {0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7};
     const label l[] = {1, 2, 3, 0, 4, 5, 6, 7, 5, 6, 7, 4};
+
     for (label j = 0; j < 12; ++j)
     {
-        length += mag(initPt(k[j]) - initPt(l[j]));
+        length += mag
+        (
+            initPt(shape[k[j]])
+          - initPt(shape[l[j]])
+        );
         lengthN += mag(H[k[j]] - H[l[j]]);
     }
     length /= lengthN;

--- a/MeshSmoother/SmootherCell.H
+++ b/MeshSmoother/SmootherCell.H
@@ -1,6 +1,7 @@
 /*---------------------------------------------------------------------------*\
   extBlockMesh
   Copyright (C) 2014 Etudes-NG
+  Copyright (C) 2020 OpenCFD Ltd.
   ---------------------------------
 License
     This file is part of extBlockMesh.
@@ -40,22 +41,25 @@ namespace Foam
 
 class SmootherCell
 {
+    // Static Data
 
-    //- Private data
-
-        // Pointer of smoother boundary
+        // Pointer to smoother boundary
         static SmootherBoundary* _bnd;
 
         // Transformation parameter
         static scalar _transParam;
 
-        // Cell quality (mean ratio)
-        scalar _quality;
+
+    // Private Data
 
         // Reference of cell shape
         const cellShape& _cellShape;
 
-    //- Private member functions
+        //- Cell quality (mean ratio)
+        scalar _quality;
+
+
+    // Private Member Functions
 
         // Tetrahedral quality computation
         scalar tetCellQuality(const label ref) const;
@@ -70,20 +74,31 @@ public:
     //- Constructors
 
         //- Construct from cellShape
-        SmootherCell(const cellShape& cell);
+        explicit SmootherCell(const cellShape& shape);
 
 
-    //- Member functions
+    //- Destructor
+    ~SmootherCell() = default;
 
-        // Set/get cell quality
-        const scalar& quality() const{return _quality;}
+
+    // Member Functions
+
+        // Set static values
+        static void setStaticItems(SmootherBoundary* bnd, const scalar t);
+
+        // Copy clone
+        autoPtr<SmootherCell> clone() const
+        {
+            return autoPtr<SmootherCell>(new SmootherCell(*this));
+        }
+
+        // The cell quality
+        constexpr scalar quality() const noexcept { return _quality; }
+
         void computeQuality();
 
         // Transform cell
         pointField geometricTransform();
-
-        // Set/get polyMesh
-        void setStaticItems(SmootherBoundary *bnd, const scalar& t);
 };
 
 const point &SmootherCell::initPt(const label p) const

--- a/MeshSmoother/SmootherCell.H
+++ b/MeshSmoother/SmootherCell.H
@@ -62,11 +62,22 @@ class SmootherCell
     // Private Member Functions
 
         // Tetrahedral quality computation
-        scalar tetCellQuality(const label ref) const;
+        static scalar tetCellQuality
+        (
+            const cellShape& shape,
+            const label ref
+        );
 
-        // get point from cell position
-        inline const point& initPt(const label p) const;
-        inline const point& relaxPt(const label p) const;
+
+        inline static const point& initPt(const label pointi)
+        {
+            return _bnd->pt(pointi)->getInitialPoint();
+        }
+
+        inline static const point& relaxPt(const label pointi)
+        {
+            return _bnd->pt(pointi)->getRelaxedPoint();
+        }
 
 
 public:
@@ -81,35 +92,42 @@ public:
     ~SmootherCell() = default;
 
 
-    // Member Functions
+    // Static Functions
 
-        // Set static values
+        //- Set static values
         static void setStaticItems(SmootherBoundary* bnd, const scalar t);
 
-        // Copy clone
+        //- The cell quality for (hex) cell shape
+        static scalar quality(const cellShape& shape);
+
+        //- Transform (hex) cell
+        static pointField geometricTransform(const cellShape& shape);
+
+
+    // Member Functions
+
+        //- Copy clone
         autoPtr<SmootherCell> clone() const
         {
             return autoPtr<SmootherCell>(new SmootherCell(*this));
         }
 
-        // The cell quality
+        //- The current cell quality
         constexpr scalar quality() const noexcept { return _quality; }
 
-        void computeQuality();
+        //- Calculate the cell quality
+        inline void computeQuality()
+        {
+            _quality = SmootherCell::quality(_cellShape);
+        }
 
-        // Transform cell
-        pointField geometricTransform();
+        //- Transform (hex) cell
+        inline pointField geometricTransform() const
+        {
+            return SmootherCell::geometricTransform(_cellShape);
+        }
 };
 
-const point &SmootherCell::initPt(const label p) const
-{
-    return _bnd->pt(_cellShape[p])->getInitialPoint();
-}
-
-const point &SmootherCell::relaxPt(const label p) const
-{
-    return _bnd->pt(_cellShape[p])->getRelaxedPoint();
-}
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/MeshSmoother/SmootherControl.C
+++ b/MeshSmoother/SmootherControl.C
@@ -26,19 +26,34 @@ License
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
-Foam::SmootherControl::SmootherControl(dictionary *smootherDict)
+Foam::SmootherControl::SmootherControl
+(
+    const dictionary& smootherDict,
+    const word& subDictName
+)
 {
     // Get smoother parameters
-    const dictionary& smoothDic = smootherDict->subDict("smoothControls");
+    const dictionary& ctrls = smootherDict.subDict(subDictName);
 
-    smoothDic.readEntry("maxIterations", _maxIterations);
-    smoothDic.readEntry("transformParameter", _transformParam);
-    smoothDic.readEntry("meanImprovTol", _meanImprovTol);
-    smoothDic.readEntry("maxMinCycleNoChange", _maxMinCycleNoChange);
-    smoothDic.readEntry("meanRelaxationTable", _meanRelaxTable);
-    smoothDic.readEntry("minRelaxationTable", _minRelaxTable);
-    smoothDic.readEntry("snapRelaxationTable", _snapRelaxTable);
-    smoothDic.readEntry("ratioWorstQualityForMin", _ratioForMin);
+    #if (OPENFOAM >= 1812)
+    ctrls.readEntry("maxIterations", _maxIterations);
+    ctrls.readEntry("transformParameter", _transformParam);
+    ctrls.readEntry("meanImprovTol", _meanImprovTol);
+    ctrls.readEntry("maxMinCycleNoChange", _maxMinCycleNoChange);
+    ctrls.readEntry("meanRelaxationTable", _meanRelaxTable);
+    ctrls.readEntry("minRelaxationTable", _minRelaxTable);
+    ctrls.readEntry("snapRelaxationTable", _snapRelaxTable);
+    ctrls.readEntry("ratioWorstQualityForMin", _ratioForMin);
+    #else
+    ctrls.lookup("maxIterations") >> _maxIterations;
+    ctrls.lookup("transformParameter") >> _transformParam;
+    ctrls.lookup("meanImprovTol") >> _meanImprovTol;
+    ctrls.lookup("maxMinCycleNoChange") >> _maxMinCycleNoChange;
+    ctrls.lookup("meanRelaxationTable") >> _meanRelaxTable;
+    ctrls.lookup("minRelaxationTable") >> _minRelaxTable;
+    ctrls.lookup("snapRelaxationTable") >> _snapRelaxTable;
+    ctrls.lookup("ratioWorstQualityForMin") >> _ratioForMin;
+    #endif
 
     if (_meanRelaxTable.last() > VSMALL)
     {

--- a/MeshSmoother/SmootherControl.H
+++ b/MeshSmoother/SmootherControl.H
@@ -23,6 +23,7 @@ License
 #ifndef MESHSMOOTHERCONTROL_H
 #define MESHSMOOTHERCONTROL_H
 
+#include "word.H"
 #include "scalarList.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
@@ -39,8 +40,7 @@ class dictionary;
 
 class SmootherControl
 {
-
-    //- Private data
+    // Private data
 
         scalarList _meanRelaxTable;
         scalarList _minRelaxTable;
@@ -52,12 +52,18 @@ class SmootherControl
         label _maxIterations;
 
 public:
+
     //- Constructors
 
         //- Construct from dictionary
-        SmootherControl(dictionary *smootherDict);
+        explicit SmootherControl
+        (
+            const dictionary& smootherDict,
+            const word& subDictName = "smoothControls"
+        );
 
-    //- Member functions
+
+    // Member Functions
 
         // Get iteration limit
         const label& maxIteration() const {return _maxIterations;}

--- a/MeshSmoother/SmootherParameter.H
+++ b/MeshSmoother/SmootherParameter.H
@@ -41,7 +41,7 @@ class MeshSmoother;
 
 class SmootherParameter
 {
-    //- Private data
+    // Private Data
 
         // Enum iteration type
         enum cycleStatus
@@ -71,12 +71,14 @@ class SmootherParameter
         scalar _meanQuality;
 
 public:
-    //- Constructors
 
-        //- Construct from polyMesh and dictionary
+    // Constructors
+
+        //- Construct from control and polyMesh
         SmootherParameter(SmootherControl *control, polyMesh* poly);
 
-    //- Member functions
+
+    // Member functions
 
         // Print
         void printHeaders() const;

--- a/MeshSmoother/backports/polyField/README.txt
+++ b/MeshSmoother/backports/polyField/README.txt
@@ -1,0 +1,10 @@
+Corresponds to meshTools polyFields from OpenFOAM-v1806 and later.
+
+- provides a simple means of writing an internal dimensioned field
+  when fvMesh is not available (eg, during mesh creation).
+
+
+Changes
+-------
+
+2020-10-09 : added. Filenames and include guards changed to avoid conflicts

--- a/MeshSmoother/backports/polyField/backport_polyFields.C
+++ b/MeshSmoother/backports/polyField/backport_polyFields.C
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2018 OpenCFD Ltd.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "backport_polyFields.H"
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+// Naming to shadow volScalarField::Internal etc.
+// keep synchronized with finiteVolume volFields.C
+
+template<>
+const word DimensionedField<scalar, polyGeoMesh>::typeName
+(
+    "volScalarField::Internal"
+);
+
+template<>
+const word DimensionedField<vector, polyGeoMesh>::typeName
+(
+    "volVectorField::Internal"
+);
+
+template<>
+const word DimensionedField<sphericalTensor, polyGeoMesh>::typeName
+(
+    "volSphericalTensorField::Internal"
+);
+
+template<>
+const word DimensionedField<symmTensor, polyGeoMesh>::typeName
+(
+    "volSymmTensorField::Internal"
+);
+
+template<>
+const word DimensionedField<tensor, polyGeoMesh>::typeName
+(
+    "volTensorField::Internal"
+);
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// ************************************************************************* //

--- a/MeshSmoother/backports/polyField/backport_polyFields.H
+++ b/MeshSmoother/backports/polyField/backport_polyFields.H
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2018 OpenCFD Ltd.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+InClass
+    Foam::polyFields
+
+Description
+    A polyMesh-based naming and storage for internal volume fields when a
+    Foam::fvMesh is unavailable.  Use sparingly.
+
+SourceFields
+    polyFields.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef backport_polyFields_H
+#define backport_polyFields_H
+
+#include "DimensionedField.H"
+#include "backport_polyGeoMesh.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+typedef DimensionedField<scalar,polyGeoMesh> polyScalarField;
+typedef DimensionedField<vector,polyGeoMesh> polyVectorField;
+typedef DimensionedField<sphericalTensor,polyGeoMesh> polySphericalTensorField;
+typedef DimensionedField<symmTensor,polyGeoMesh> polySymmTensorField;
+typedef DimensionedField<tensor,polyGeoMesh> polyTensorField;
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/MeshSmoother/backports/polyField/backport_polyGeoMesh.H
+++ b/MeshSmoother/backports/polyField/backport_polyGeoMesh.H
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2018 OpenCFD Ltd.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::polyGeoMesh
+
+Description
+    The polyMesh GeoMesh for holding internal fields without an fvMesh.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef backport_polyGeoMesh_H
+#define backport_polyGeoMesh_H
+
+#include "GeoMesh.H"
+#include "polyMesh.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                         Class polyGeoMesh Declaration
+\*---------------------------------------------------------------------------*/
+
+class polyGeoMesh
+:
+    public GeoMesh<polyMesh>
+{
+public:
+
+    // Constructors
+
+        //- Construct from polyMesh reference
+        explicit polyGeoMesh(const polyMesh& mesh)
+        :
+            GeoMesh<polyMesh>(mesh)
+        {}
+
+
+    // Member Functions
+
+        //- Return size
+        static label size(const polyMesh& mesh)
+        {
+            return mesh.nCells();
+        }
+
+        //- Return size
+        label size() const
+        {
+            return size(mesh_);
+        }
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/extBlockMesh/Make/options
+++ b/extBlockMesh/Make/options
@@ -25,9 +25,9 @@ EXE_LIBS = \
     -L$(FOAM_MODULE_LIBBIN) \
     -lMeshSmoother
 
-/* OpenFOAM-v1806 and later: no separate triSurface */
+/* Prior to OpenFOAM-v1806: separate triSurface */
 #if (OPENFOAM < 1806)
+
 EXE_INC += -I$(LIB_SRC)/triSurface/lnInclude
 
-EXE_LIBS += -ledgeMesh
 #endif

--- a/extBlockMesh/createSmoother.H
+++ b/extBlockMesh/createSmoother.H
@@ -24,5 +24,5 @@ autoPtr<MeshSmoother> smootherPtr;
     Info<< nl << "Initialize smoother algorithm" << nl;
 
     smootherDictPtr.reset(new IOdictionary(smootherDictIO));
-    smootherPtr.reset(new MeshSmoother(&mesh, &(smootherDictPtr())));
+    smootherPtr.reset(new MeshSmoother(&mesh, smootherDictPtr()));
 }

--- a/extBlockMesh/extBlockMesh.C
+++ b/extBlockMesh/extBlockMesh.C
@@ -2,8 +2,12 @@
   =========                 |
   \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
    \\    /   O peration     |
-    \\  /    A nd           | Copyright (C) 2011-2013 OpenFOAM Foundation
+    \\  /    A nd           | www.openfoam.com
      \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2011-2013 OpenFOAM Foundation
+    Copyright (C) 2014 Etudes-NG
+    Copyright (C) 2020 OpenCFD Ltd.
 -------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
@@ -95,8 +99,13 @@ int main(int argc, char *argv[])
     argList::noParallel();
     argList::addBoolOption
     (
-        "writeStep",
-        "write mesh at different smoothing step"
+        "writeSteps",
+        "Write mesh at different smoothing steps"
+    );
+    argList::addBoolOption
+    (
+        "write-quality",
+        "Write mesh and quality field at different smoothing steps"
     );
     argList::addOption("dict", "file", "Alternative blockMeshDict");
 
@@ -120,45 +129,52 @@ int main(int argc, char *argv[])
     blockMesh blocks(meshDict, regionName);
     blocks.verbose(false);
 
-    word defaultFacesName = "defaultFaces";
-    word defaultFacesType = emptyPolyPatch::typeName;
+    // Set the precision of the points data to 10
+    IOstream::defaultPrecision(max(10u, IOstream::defaultPrecision()));
 
+    #if (OPENFOAM > 2006)
+    const word meshInstance = runTime.constant();
+
+    // Ensure we get information messages, even if turned off in dictionary
+    blocks.verbose(true);
+
+    autoPtr<polyMesh> meshPtr =
+        blocks.mesh(IOobject(regionName, meshInstance, runTime));
+
+    polyMesh& mesh = *meshPtr;
+    #else
     Info<< nl << "Creating polyMesh from blockMesh" << endl;
 
     polyMesh mesh
     (
-        IOobject
-        (
-            regionName,
-            runTime.constant(),
-            runTime
-        ),
+        IOobject(regionName, runTime.constant(), runTime),
+        #if (OPENFOAM >= 1806)
         pointField(blocks.points()),
+        #else
+        xferCopy<pointField>(blocks.points()),
+        #endif
         blocks.cells(),
         blocks.patches(),
         blocks.patchNames(),
         blocks.patchDicts(),
-        defaultFacesName,
-        defaultFacesType
+        "defaultFaces",             // defaultFacesName,
+        emptyPolyPatch::typeName    // defaultFacesType
     );
+    #endif
 
 
     // Smoothing
+    const bool withQuality = args.optionFound("write-quality");
+    const bool writeSteps = args.optionFound("writeSteps");
+
     label nWritten = 0;
     {
         #include "createSmoother.H"
         MeshSmoother& smoother = smootherPtr();
-        smoother.setBlocks(&blocks);
 
-        if (args.optionFound("writeStep"))
+        if (writeSteps || withQuality)
         {
-            nWritten += smoother.updateAndWrite
-            (
-                regionName,
-                defaultFacesName,
-                defaultFacesType,
-                runTime
-            );
+            nWritten += smoother.updateAndWrite(runTime, withQuality);
         }
         else
         {
@@ -176,16 +192,12 @@ int main(int argc, char *argv[])
     // Set any cellZones
     #include "addCellZones.H"
 
-
-    // Set the precision of the points data to 10
-    IOstream::defaultPrecision(max(10u, IOstream::defaultPrecision()));
-
-    Info<< nl << "Writing polyMesh" << endl;
-
     // #########################################################################
 
     if (!nWritten)
     {
+        Info<< nl << "Writing polyMesh" << endl;
+
         mesh.removeFiles();
         if (!mesh.write())
         {

--- a/extBlockMesh/findBlockMeshDict.H
+++ b/extBlockMesh/findBlockMeshDict.H
@@ -6,13 +6,23 @@ autoPtr<IOdictionary> meshDictPtr;
 {
     fileName dictPath;
 
-    if (args.readIfPresent("dict", dictPath))
+    if
+    (
+        #if (OPENFOAM < 1812)
+        args.optionReadIfPresent("dict", dictPath)
+        #else
+        args.readIfPresent("dict", dictPath)
+        #endif
+    )
+
     {
         // Dictionary specified on the command-line ...
 
         if (isDir(dictPath))
         {
-            dictPath /= dictName;
+            //Newer:  dictPath /= dictName;
+            //Older:
+            dictPath = dictPath / dictName;
         }
     }
     else if
@@ -64,9 +74,14 @@ autoPtr<IOdictionary> meshDictPtr;
     }
 
     Info<< "Creating block mesh from "
-        << runTime.relativePath(meshDictIO.objectPath()) << endl;
+        //Newer: << runTime.relativePath(meshDictIO.objectPath()) << endl;
+        //Older:
+        << meshDictIO.objectPath() << endl;
 
-    meshDictPtr = autoPtr<IOdictionary>::New(meshDictIO);
+    meshDictPtr.reset(new IOdictionary(meshDictIO));
 }
 
-const IOdictionary& meshDict = *meshDictPtr;
+//Newer:  const IOdictionary& meshDict = *meshDictPtr;
+
+//Older:
+const IOdictionary& meshDict = meshDictPtr();

--- a/hexMeshSmoother/Make/options
+++ b/hexMeshSmoother/Make/options
@@ -25,9 +25,9 @@ EXE_LIBS = \
     -L$(FOAM_MODULE_LIBBIN) \
     -lMeshSmoother
 
-/* OpenFOAM-v1806 and later: no separate triSurface */
+/* Prior to OpenFOAM-v1806: separate triSurface */
 #if (OPENFOAM < 1806)
+
 EXE_INC += -I$(LIB_SRC)/triSurface/lnInclude
 
-EXE_LIBS += -ledgeMesh
 #endif

--- a/hexMeshSmoother/createSmoother.H
+++ b/hexMeshSmoother/createSmoother.H
@@ -24,5 +24,5 @@ autoPtr<MeshSmoother> smootherPtr;
     Info<< nl << "Initialize smoother algorithm" << nl;
 
     smootherDictPtr.reset(new IOdictionary(smootherDictIO));
-    smootherPtr.reset(new MeshSmoother(&mesh, &(smootherDictPtr())));
+    smootherPtr.reset(new MeshSmoother(&mesh, smootherDictPtr()));
 }


### PR DESCRIPTION
- Added in polyFields from OpenFOAM-v1806, which allows use without linking finiteVolume and avoids copying the polyMesh to fvMesh.
- remove blockMesh dependency for MeshSmoother
- can now selective enable writing quality field.
- static methods for SootherCell : cuts down overhead, and allows direct storage of quality metrics and thus easier dumping as scalar field.

- tested compile with OpenFOAM-v1712 upwards. Uses updated blockMesh method for OpenFOAM-v2012 (ie, current develop version).

- plug memory leak in surface feature handling